### PR TITLE
Remove unused navigation pkgs and fix analytics

### DIFF
--- a/app/services/config.ts
+++ b/app/services/config.ts
@@ -13,8 +13,8 @@ const firebaseConfig = {
   measurementId: process.env.EXPO_PUBLIC_MEASUREMENT_ID,
 };
 
-const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
+const app = initializeApp(firebaseConfig, 'nudge-app');
+const analytics = typeof window !== 'undefined' ? getAnalytics(app) : null;
 const db = getFirestore(app);
 const auth = getAuth(app);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.2",
-        "@react-navigation/bottom-tabs": "^7.2.0",
-        "@react-navigation/native": "^7.0.14",
-        "@react-navigation/native-stack": "^7.2.0",
         "expo": "~52.0.30",
         "expo-blur": "~14.0.3",
         "expo-constants": "~17.0.5",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
-    "@react-navigation/bottom-tabs": "^7.2.0",
-    "@react-navigation/native": "^7.0.14",
-    "@react-navigation/native-stack": "^7.2.0",
     "expo": "~52.0.30",
     "expo-blur": "~14.0.3",
     "expo-constants": "~17.0.5",


### PR DESCRIPTION
- Removes unused navigation packages, since we're using expo-router
- Fixes Firebase analytics by checking if the app is on a web browser during initialization

https://github.com/user-attachments/assets/3bec9d3b-888a-464b-b2ba-9326b96a5772