### PR TITLE
Persist Firebase User Login Credentials

### DIFF
--- a/app/screens/login.tsx
+++ b/app/screens/login.tsx
@@ -4,7 +4,7 @@ import {
   onAuthStateChanged,
 } from "firebase/auth";
 import { Formik } from "formik";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Button, HelperText, Text, TextInput } from "react-native-paper";
 import * as yup from "yup";
@@ -14,17 +14,13 @@ import { router } from "expo-router";
 const LoginScreen = () => {
   const [passwordVisible, setPasswordVisible] = useState(false);
 
-  useEffect(() => {
-    const auth = getAuth(app);
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      if (user) {
-        // User is signed in, redirect to the home screen
-        router.push("/screens/welcome");
-      }
-    });
-
-    // Cleanup subscription on unmount
-    return () => unsubscribe();
+  const auth = getAuth(app);
+  const unsubscribe = onAuthStateChanged(auth, (user) => {
+    if (user) {
+      // User is signed in, redirect to the home screen
+      router.push("/screens/welcome");
+      unsubscribe();
+    }
   });
 
   const updatePasswordVisibility = () => {

--- a/app/screens/login.tsx
+++ b/app/screens/login.tsx
@@ -8,13 +8,12 @@ import React, { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Button, HelperText, Text, TextInput } from "react-native-paper";
 import * as yup from "yup";
-import { app } from "../services/config";
+import { app, auth } from "../services/config";
 import { router } from "expo-router";
 
 const LoginScreen = () => {
   const [passwordVisible, setPasswordVisible] = useState(false);
 
-  const auth = getAuth(app);
   const unsubscribe = onAuthStateChanged(auth, (user) => {
     if (user) {
       // User is signed in, redirect to the home screen

--- a/app/screens/login.tsx
+++ b/app/screens/login.tsx
@@ -1,13 +1,31 @@
-import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  onAuthStateChanged,
+} from "firebase/auth";
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { StyleSheet, View } from "react-native";
 import { Button, HelperText, Text, TextInput } from "react-native-paper";
 import * as yup from "yup";
 import { app } from "../services/config";
+import { router } from "expo-router";
 
 const LoginScreen = () => {
   const [passwordVisible, setPasswordVisible] = useState(false);
+
+  useEffect(() => {
+    const auth = getAuth(app);
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        // User is signed in, redirect to the home screen
+        router.push("/screens/welcome");
+      }
+    });
+
+    // Cleanup subscription on unmount
+    return () => unsubscribe();
+  });
 
   const updatePasswordVisibility = () => {
     setPasswordVisible(!passwordVisible);

--- a/app/screens/login.tsx
+++ b/app/screens/login.tsx
@@ -4,7 +4,7 @@ import {
   onAuthStateChanged,
 } from "firebase/auth";
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { StyleSheet, View } from "react-native";
 import { Button, HelperText, Text, TextInput } from "react-native-paper";
 import * as yup from "yup";
@@ -14,13 +14,17 @@ import { router } from "expo-router";
 const LoginScreen = () => {
   const [passwordVisible, setPasswordVisible] = useState(false);
 
-  const unsubscribe = onAuthStateChanged(auth, (user) => {
-    if (user) {
-      // User is signed in, redirect to the home screen
-      router.push("/screens/welcome");
-      unsubscribe();
-    }
-  });
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        // User is signed in, redirect to the welcome screen
+        router.push("/screens/welcome");
+      }
+    });
+
+    // Cleanup subscription on unmount
+    return () => unsubscribe();
+  }, []);
 
   const updatePasswordVisibility = () => {
     setPasswordVisible(!passwordVisible);
@@ -38,16 +42,17 @@ const LoginScreen = () => {
       initialValues={{ email: "", password: "" }}
       validationSchema={loginValidationSchema}
       validateOnBlur={false}
-      onSubmit={(values, errors) => {
+      onSubmit={(values, { setFieldError }) => {
         const auth = getAuth(app);
         signInWithEmailAndPassword(auth, values.email, values.password)
           .then((userCredential) => {
             const user = userCredential.user;
+            // Handle successful login
+            router.push("/screens/welcome");
           })
           .catch((error) => {
-            const errorCode = error.code;
             const errorMessage = error.message;
-            errors.setFieldError("password", errorMessage);
+            setFieldError("password", errorMessage);
           });
       }}
     >
@@ -140,7 +145,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#fff", // remove?
+    backgroundColor: "#fff",
     paddingHorizontal: 20,
   },
   title: {
@@ -148,9 +153,6 @@ const styles = StyleSheet.create({
   },
   textField: {
     width: 300,
-  },
-  textFieldContainer: {
-    padding: 24,
   },
   buttonContainer: {
     width: 100,

--- a/app/screens/welcome.tsx
+++ b/app/screens/welcome.tsx
@@ -1,7 +1,32 @@
-import { Text } from "react-native";
+import { getAuth } from "firebase/auth";
+import { Text, View } from "react-native";
+import { app } from "../services/config";
+import { Button } from "react-native-paper";
+import { router } from "expo-router";
 
-const WelcomeScreen = ({ navigation }) => {
-  return <Text>welcome!</Text>;
+const auth = getAuth(app);
+
+const WelcomeScreen = () => {
+  return (
+    <View>
+      <Text>
+        welcome{auth.currentUser ? " " + auth.currentUser.email : ""}!
+      </Text>
+      {auth.currentUser ? (
+        <Button
+          onPress={() => {
+            auth.signOut().then(() => {
+              router.push("/screens/login");
+            });
+          }}
+        >
+          Sign out
+        </Button>
+      ) : (
+        ""
+      )}
+    </View>
+  );
 };
 
 export default WelcomeScreen;

--- a/app/screens/welcome.tsx
+++ b/app/screens/welcome.tsx
@@ -1,17 +1,28 @@
-import { getAuth } from "firebase/auth";
 import { Text, View } from "react-native";
-import { app } from "../services/config";
+import { auth } from "../services/config";
 import { Button } from "react-native-paper";
 import { router } from "expo-router";
-
-const auth = getAuth(app);
+import { onAuthStateChanged } from "firebase/auth";
+import { useState, useEffect } from "react";
 
 const WelcomeScreen = () => {
+  const [email, setEmail] = useState<string>("");
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user && user.email) {
+        console.log(user.email);
+        setEmail(user.email);
+      }
+    });
+
+    // Cleanup subscription on unmount
+    return () => unsubscribe();
+  }, []);
+
   return (
     <View>
-      <Text>
-        welcome{auth.currentUser ? " " + auth.currentUser.email : ""}!
-      </Text>
+      <Text>{email ? `Welcome ${email}!` : "Welcome!"}</Text>
       {auth.currentUser ? (
         <Button
           onPress={() => {
@@ -22,9 +33,7 @@ const WelcomeScreen = () => {
         >
           Sign out
         </Button>
-      ) : (
-        ""
-      )}
+      ) : null}
     </View>
   );
 };

--- a/app/services/config.ts
+++ b/app/services/config.ts
@@ -1,6 +1,10 @@
 import { getAnalytics, isSupported } from "firebase/analytics";
 import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
+import {
+  browserLocalPersistence,
+  getAuth,
+  setPersistence,
+} from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
@@ -21,7 +25,7 @@ if (typeof window !== "undefined") {
   );
 }
 const db = getFirestore(app);
-// TODO: setup persistence so user can remain logged in
 const auth = getAuth(app);
+setPersistence(auth, browserLocalPersistence);
 
 export { analytics, app, auth, db };


### PR DESCRIPTION
- Persist user login
- Use welcome page to display user email (if signed in)
- Add sign out button to welcome page (temporary to test persistence)

https://github.com/user-attachments/assets/0ad6ceaa-29cb-4fd8-a9e2-69d73095930c

